### PR TITLE
feat: add resource server support for custom OAuth scopes

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,6 +10,17 @@ module "congito_userpool" {
 
   domain = { enabled = true }
 
+  resource_servers = {
+    api = {
+      identifier = "api"
+      name       = "Example API"
+      scopes = {
+        read  = { description = "Read access" }
+        write = { description = "Write access" }
+      }
+    }
+  }
+
   context = module.example_label.context # not required
 }
 

--- a/main.tf
+++ b/main.tf
@@ -175,6 +175,24 @@ resource "aws_cognito_user_pool_domain" "domain" {
   user_pool_id    = aws_cognito_user_pool.this[0].id
 }
 
+# -------------------------------------------------------- resource_server ---
+
+resource "aws_cognito_resource_server" "this" {
+  for_each = local.enabled ? var.resource_servers : {}
+
+  identifier   = each.value.identifier
+  name         = each.value.name
+  user_pool_id = aws_cognito_user_pool.this[0].id
+
+  dynamic "scope" {
+    for_each = { for k, v in each.value.scopes : k => v if v.enabled }
+    content {
+      scope_name        = scope.key
+      scope_description = scope.value.description
+    }
+  }
+}
+
 # ---------------------------------------------------------------------- iam ---
 
 module "cognito_userpool_sms_label" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,13 @@ output "last_modified_date" {
   description = "Date the userpool was last modified."
   value       = local.enabled ? aws_cognito_user_pool.this[0].last_modified_date : null
 }
+
+output "resource_servers" {
+  description = "Map of resource servers with their identifiers and scope identifiers."
+  value = {
+    for k, v in aws_cognito_resource_server.this : k => {
+      identifier        = v.identifier
+      scope_identifiers = v.scope_identifiers
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -231,6 +231,19 @@ variable "verification_message_template" {
   default     = {}
 }
 
+variable "resource_servers" {
+  type = map(object({
+    identifier = string
+    name       = string
+    scopes = optional(map(object({
+      enabled     = optional(bool, true)
+      description = string
+    })), {})
+  }))
+  description = "Map of resource server configurations. Each resource server defines custom OAuth scopes for an API."
+  default     = {}
+}
+
 # =================================================================== deprecated ===
 
 variable "email_verification_message" {


### PR DESCRIPTION
## Summary

- Adds support for `aws_cognito_resource_server` resources, enabling custom OAuth scopes for APIs
- Uses a `map(object({...}))` variable where scopes are also a map keyed by scope name, with `enabled` and `description` attributes
- Outputs each resource server's `identifier` and `scope_identifiers` (fully qualified scope names like `api/read`)

## Usage

```hcl
resource_servers = {
  api = {
    identifier = "https://api.example.com"
    name       = "My API"
    scopes = {
      read  = { description = "Read access" }
      write = { description = "Write access" }
    }
  }
}
```

## Changes

- **`variables.tf`** — New `resource_servers` variable with `map(object)` type
- **`main.tf`** — New `aws_cognito_resource_server.this` resource using `for_each` with dynamic scope blocks
- **`outputs.tf`** — New `resource_servers` output
- **`examples/complete/main.tf`** — Updated example with a sample resource server